### PR TITLE
Sort releases by published_at desc

### DIFF
--- a/src/app/common/web/release.ts
+++ b/src/app/common/web/release.ts
@@ -1,3 +1,4 @@
 export class Release {
     name: string
+    published_at: string
 }

--- a/src/app/index/index.component.ts
+++ b/src/app/index/index.component.ts
@@ -14,7 +14,9 @@ export class IndexComponent {
   constructor(private httpClient: HttpClient) {
     this.httpClient.get('https://api.github.com/repos/JoKronk/teamruns-client/releases').subscribe(releases => {
       this.release = (releases as Release[]).sort(function (a, b) {
-        return ('' + b.name).localeCompare(a.name);
+        let dateA = Date.parse(a.published_at),
+          dateB = Date.parse(b.published_at);
+        return dateB - dateA;
       })[0].name.substring(1);
     });
 


### PR DESCRIPTION
fixes the issue going from `v0.9.0` to `v0.10.0`

I think Zed renamed the actual files on the v0.10.0 release, so we should rename those back / duplicate the assets with both names when this gets deployed